### PR TITLE
Clean up g-counter

### DIFF
--- a/src/4_grow_only_counter.clj
+++ b/src/4_grow_only_counter.clj
@@ -2,7 +2,7 @@
 (load-file (clojure.string/replace *file* #"/[^/]+$" "/node.clj"))
 
 (ns grow-only-counter
-  (:require [node :refer [then]]))
+  (:require [node]))
 
 ;;;; Grow-only counter, state-based CRDT implemented with a version vector and gossip.
 

--- a/src/5a_single_node_kafka.clj
+++ b/src/5a_single_node_kafka.clj
@@ -1,11 +1,8 @@
 #!/usr/bin/env bb
-(ns single-node-kafka)
+(load-file (clojure.string/replace *file* #"/[^/]+$" "/node.clj"))
 
-(require '[babashka.classpath :as cp])
-(require '[babashka.fs :as fs])
-(cp/add-classpath (str (fs/file (fs/parent *file*))))
-
-(require 'node)
+(ns single-node-kafka
+  (:require [node]))
 
 ;;;; A single node log
 

--- a/src/node.clj
+++ b/src/node.clj
@@ -25,19 +25,6 @@
     (catch Exception _
       nil)))
 
-(defn- generate-json
-  "Generate json string from input"
-  [input]
-  (when input
-    (json/generate-string input)))
-
-(defn- printout
-  "Print the received input to stdout"
-  [input]
-  (when input
-    (locking *out* ;; this locking is essential for thread safety
-      (println input))))
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; state
@@ -69,19 +56,11 @@
     (binding [*out* *err*] ;; this locking is essential for thread safety
       (println input))))
 
-(defn- fmt-msg
-  "Format a message with source node, destination node, and message body."
-  [src dest body]
-  {:src src
-   :dest dest
-   :body body})
-
 (defn send!
   "Send a message."
   [dest body]
-  (-> (fmt-msg @node-id dest body)
-      generate-json
-      printout))
+  (locking *out*
+    (println (json/generate-string {:src @node-id :dest dest :body body}))))
 
 (defn reply!
   "Replies to a request message with the given body."


### PR DESCRIPTION
just added the rpc code to remove it :)

i didn't realize that init gave us knowledge of all other nodes. we now have a clean g-counter crdt with no reliance on the sequentially consistent kv store!